### PR TITLE
User data patch

### DIFF
--- a/todo_list/base/models.py
+++ b/todo_list/base/models.py
@@ -1,8 +1,9 @@
 from django.db import models
 from django.contrib.auth.models import User
+from django.conf import settings
 
 class Task(models.Model):
-    user = models.ForeignKey(User, on_delete=models.CASCADE, null=True, blank=True)
+    user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE, null=True, blank=True)
     title = models.CharField(max_length=200)
     description = models.TextField(null=True, blank=True)
     complete = models.BooleanField(default=False)

--- a/todo_list/base/views.py
+++ b/todo_list/base/views.py
@@ -73,6 +73,11 @@ class TaskUpdate(LoginRequiredMixin, UpdateView):
     model = Task
     fields = ['title', 'description', 'complete'] 
     success_url = reverse_lazy('tasks')
+    def get_queryset (self) :
+        print ('update get _queryset called')
+        # Limit a User to only modifying their own data.
+        qs = super(TaskUpdate, self).get_queryset()
+        return qs.filter(user=self.request.user)
 
 class TaskDelete(LoginRequiredMixin, DeleteView):
     model = Task


### PR DESCRIPTION
Udpate models.py: use settings.AUTH_USER_MODEL instead of django contrib auth models User. Update views.py: extend get_queryset method to filter by user to not allow users from updating other users tasks